### PR TITLE
Openx: Pass through imp.ext wholesale except prebid, bidder

### DIFF
--- a/adapters/openx/openx.go
+++ b/adapters/openx/openx.go
@@ -19,10 +19,7 @@ type OpenxAdapter struct {
 	endpoint   string
 }
 
-type openxImpExt struct {
-	CustomParams       map[string]interface{}             `json:"customParams,omitempty"`
-	AuctionEnvironment openrtb_ext.AuctionEnvironmentType `json:"ae,omitempty"`
-}
+type openxImpExt map[string]json.RawMessage
 
 type openxReqExt struct {
 	DelDomain    string `json:"delDomain,omitempty"`
@@ -140,18 +137,26 @@ func preprocess(imp *openrtb2.Imp, reqExt *openxReqExt) error {
 		imp.BidFloor = openxExt.CustomFloor
 	}
 
+	// outgoing imp.ext should be same as incoming imp.ext minus prebid and bidder
 	impExt := openxImpExt{}
-	addImpExt := false
+	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
+		return &errortypes.BadInput{
+			Message: err.Error(),
+		}
+	}
+	delete(impExt, "bidder")
+	delete(impExt, "prebid")
 
 	if openxExt.CustomParams != nil {
-		impExt.CustomParams = openxExt.CustomParams
-		addImpExt = true
+		var err error
+		if impExt["customParams"], err = json.Marshal(openxExt.CustomParams); err != nil {
+			return &errortypes.BadInput{
+				Message: err.Error(),
+			}
+		}
 	}
-	if bidderExt.AuctionEnvironment != openrtb_ext.ServerSideAuction {
-		impExt.AuctionEnvironment = bidderExt.AuctionEnvironment
-		addImpExt = true
-	}
-	if addImpExt {
+
+	if len(impExt) > 0 {
 		var err error
 		if imp.Ext, err = json.Marshal(impExt); err != nil {
 			return &errortypes.BadInput{

--- a/adapters/openx/openxtest/exemplary/imp-ext-passthrough.json
+++ b/adapters/openx/openxtest/exemplary/imp-ext-passthrough.json
@@ -1,0 +1,83 @@
+{
+  "mockBidRequest": {
+    "id": "test-request-id",
+    "imp": [
+      {
+        "id": "test-imp-id",
+        "banner": {
+          "format": [{"w": 728, "h": 90}]
+        },
+        "ext": {
+          "ae": 1,
+          "bidder": {
+            "unit": "539439964",
+            "delDomain": "se-demo-d.openx.net",
+            "customParams": {"foo": "bar"}
+          },
+          "data": {
+            "pbadslot": "adslotvalue"
+          },
+          "gpid": "gpidvalue",
+          "otherfields": "othervalues",
+          "prebid": {
+            "foo": "bar"
+          },
+          "skadn": {
+            "version": "2.0"
+          }
+        }
+      }
+    ]
+  },
+
+  "httpCalls": [
+    {
+      "expectedRequest": {
+        "uri": "http://rtb.openx.net/prebid",
+        "body": {
+          "id": "test-request-id",
+          "imp": [
+            {
+              "id": "test-imp-id",
+              "banner": {
+                "format": [{"w": 728, "h": 90}]
+              },
+              "tagid": "539439964",
+              "ext": {
+                "ae": 1,
+                "customParams": {"foo": "bar"},
+                "data": {
+                  "pbadslot": "adslotvalue"
+                },
+                "gpid": "gpidvalue",
+                "otherfields": "othervalues",
+                "skadn": {
+                  "version": "2.0"
+                }
+              }
+            }
+          ],
+          "ext": {
+            "bc": "hb_pbs_1.0.0",
+            "delDomain": "se-demo-d.openx.net"
+          }
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {
+          "id": "test-request-id",
+          "cur": "USD",
+          "nbr": 1
+        }
+      }
+    }
+  ],
+
+  "expectedBidResponses": [
+    {
+      "currency": "USD",
+      "bids": []
+    }
+  ]
+}

--- a/adapters/smaato/smaatotest/exemplary/native.json
+++ b/adapters/smaato/smaatotest/exemplary/native.json
@@ -35,6 +35,15 @@
                 "data": {}
             }
         },
+        "regs": {
+            "coppa": 1,
+            "ext": {
+                "gdpr": 1,
+                "us_privacy": "uspConsentString",
+                "gpp": "gppString",
+                "gpp_sid": [7]
+            }
+        },
         "ext": {
             "prebid": {
                 "auctiontimestamp": 1598262728811,
@@ -81,6 +90,15 @@
                     "site": {
                         "publisher": {
                             "id": "1100042525"
+                        }
+                    },
+                    "regs": {
+                        "coppa": 1,
+                        "ext": {
+                            "gdpr": 1,
+                            "us_privacy": "uspConsentString",
+                            "gpp": "gppString",
+                            "gpp_sid": [7]
                         }
                     },
                     "ext": {

--- a/adapters/smaato/smaatotest/exemplary/simple-banner.json
+++ b/adapters/smaato/smaatotest/exemplary/simple-banner.json
@@ -64,7 +64,9 @@
       "coppa": 1,
       "ext": {
         "gdpr": 1,
-        "us_privacy": "uspConsentString"
+        "us_privacy": "uspConsentString",
+        "gpp": "gppString",
+        "gpp_sid": [7]
       }
     }
   },
@@ -118,7 +120,9 @@
             "coppa": 1,
             "ext": {
               "gdpr": 1,
-              "us_privacy": "uspConsentString"
+              "us_privacy": "uspConsentString",
+              "gpp": "gppString",
+              "gpp_sid": [7]
             }
           },
           "site": {

--- a/adapters/smaato/smaatotest/exemplary/video.json
+++ b/adapters/smaato/smaatotest/exemplary/video.json
@@ -56,6 +56,15 @@
                 "data": {}
             }
         },
+        "regs": {
+            "coppa": 1,
+            "ext": {
+                "gdpr": 1,
+                "us_privacy": "uspConsentString",
+                "gpp": "gppString",
+                "gpp_sid": [7]
+            }
+        },
         "ext": {
             "prebid": {
                 "auctiontimestamp": 1598262728811,
@@ -115,6 +124,15 @@
                     ],
                     "user": {
                         "ext": {
+                        }
+                    },
+                    "regs": {
+                        "coppa": 1,
+                        "ext": {
+                            "gdpr": 1,
+                            "us_privacy": "uspConsentString",
+                            "gpp": "gppString",
+                            "gpp_sid": [7]
                         }
                     },
                     "device": {

--- a/config/bidderinfo.go
+++ b/config/bidderinfo.go
@@ -133,7 +133,7 @@ type Syncer struct {
 // In most cases, bidders will specify a URL with a `{{.RedirectURL}}` macro for the call back to
 // Prebid Server and a UserMacro which the bidder server will replace with the user's id. Example:
 //
-//	url: "https://sync.bidderserver.com/usersync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+//	url: "https://sync.bidderserver.com/usersync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}"
 //	userMacro: "$UID"
 //
 // Prebid Server is configured with a default RedirectURL template matching the /setuid call. This
@@ -152,6 +152,8 @@ type SyncerEndpoint struct {
 	//  {{.GDPR}}        - This will be replaced with the "gdpr" property sent to /cookie_sync.
 	//  {{.Consent}}     - This will be replaced with the "consent" property sent to /cookie_sync.
 	//  {{.USPrivacy}}   - This will be replaced with the "us_privacy" property sent to /cookie_sync.
+	//  {{.GPP}}		 - This will be replaced with the "gpp" property sent to /cookie_sync.
+	//  {{.GPPSID}}		 - This will be replaced with the "gpp_sid" property sent to /cookie_sync.
 	URL string `yaml:"url" mapstructure:"url"`
 
 	// RedirectURL is an endpoint on the host server the user will be redirected to when a user sync
@@ -165,7 +167,7 @@ type SyncerEndpoint struct {
 	//  {{.UserMacro}}   - This will be replaced with the bidder server's user id macro.
 	//
 	// The endpoint on the host server is usually Prebid Server's /setuid endpoint. The default value is:
-	// `{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&f={{.SyncType}}&uid={{.UserMacro}}`
+	// `{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&f={{.SyncType}}&uid={{.UserMacro}}`
 	RedirectURL string `yaml:"redirectUrl" mapstructure:"redirect_url"`
 
 	// ExternalURL is available as a macro to the RedirectURL template. If not specified, either the syncer configuration

--- a/config/config.go
+++ b/config/config.go
@@ -933,7 +933,7 @@ func SetupViper(v *viper.Viper, filename string, bidderInfos BidderInfos) {
 
 	// some adapters append the user id to the end of the redirect url instead of using
 	// macro substitution. it is important for the uid to be the last query parameter.
-	v.SetDefault("user_sync.redirect_url", "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&f={{.SyncType}}&uid={{.UserMacro}}")
+	v.SetDefault("user_sync.redirect_url", "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&f={{.SyncType}}&uid={{.UserMacro}}")
 
 	v.SetDefault("max_request_size", 1024*256)
 	v.SetDefault("analytics.file.filename", "")

--- a/endpoints/cookie_sync.go
+++ b/endpoints/cookie_sync.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prebid/prebid-server/privacy"
 	"github.com/prebid/prebid-server/privacy/ccpa"
 	gdprPrivacy "github.com/prebid/prebid-server/privacy/gdpr"
+	gppPrivacy "github.com/prebid/prebid-server/privacy/gpp"
 	"github.com/prebid/prebid-server/stored_requests"
 	"github.com/prebid/prebid-server/usersync"
 )
@@ -153,6 +154,10 @@ func (c *cookieSyncEndpoint) parseRequest(r *http.Request) (usersync.Request, pr
 		},
 		CCPA: ccpa.Policy{
 			Consent: request.USPrivacy,
+		},
+		GPP: gppPrivacy.Policy{
+			Consent: request.GPP,
+			RawSID:  request.GPPSid,
 		},
 	}
 
@@ -398,6 +403,8 @@ type cookieSyncRequest struct {
 	GDPRConsent     string                           `json:"gdpr_consent"`
 	USPrivacy       string                           `json:"us_privacy"`
 	Limit           int                              `json:"limit"`
+	GPP             string                           `json:"gpp"`
+	GPPSid          string                           `json:"gpp_sid"`
 	CooperativeSync *bool                            `json:"coopSync"`
 	FilterSettings  *cookieSyncRequestFilterSettings `json:"filterSettings"`
 	Account         string                           `json:"account"`

--- a/endpoints/cookie_sync_test.go
+++ b/endpoints/cookie_sync_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prebid/prebid-server/privacy"
 	"github.com/prebid/prebid-server/privacy/ccpa"
 	gdprPrivacy "github.com/prebid/prebid-server/privacy/gdpr"
+	gppPrivacy "github.com/prebid/prebid-server/privacy/gpp"
 	"github.com/prebid/prebid-server/usersync"
 
 	"github.com/stretchr/testify/assert"
@@ -324,6 +325,8 @@ func TestCookieSyncParseRequest(t *testing.T) {
 				`"gdpr":1,` +
 				`"gdpr_consent":"anyGDPRConsent",` +
 				`"us_privacy":"1NYN",` +
+				`"gpp":"anyGPPString",` +
+				`"gpp_sid":"2",` +
 				`"limit":42,` +
 				`"coopSync":true,` +
 				`"filterSettings":{"iframe":{"bidders":"*","filter":"include"}, "image":{"bidders":["b"],"filter":"exclude"}}` +
@@ -343,6 +346,10 @@ func TestCookieSyncParseRequest(t *testing.T) {
 				},
 				CCPA: ccpa.Policy{
 					Consent: "1NYN",
+				},
+				GPP: gppPrivacy.Policy{
+					Consent: "anyGPPString",
+					RawSID:  "2",
 				},
 			},
 			expectedRequest: usersync.Request{

--- a/endpoints/openrtb2/amp_auction.go
+++ b/endpoints/openrtb2/amp_auction.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prebid/openrtb/v17/openrtb2"
 	"github.com/prebid/openrtb/v17/openrtb3"
 	"github.com/prebid/prebid-server/hooks/hookexecution"
+	"github.com/prebid/prebid-server/ortb"
 	"github.com/prebid/prebid-server/util/uuidutil"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 
@@ -444,16 +445,20 @@ func (deps *endpointDeps) parseAmpRequest(httpRequest *http.Request) (req *openr
 	deps.setFieldsImplicitly(httpRequest, req)
 
 	// Need to ensure cache and targeting are turned on
-	e = defaultRequestExt(req)
+	e = initAmpTargetingAndCache(req)
 	if errs = append(errs, e...); errortypes.ContainsFatalError(errs) {
 		return
 	}
 
-	// At this point, we should have a valid request that definitely has Targeting and Cache turned on
-	hasStoredResponses := len(storedAuctionResponses) > 0
+	if err := ortb.SetDefaults(req); err != nil {
+		errs = append(errs, err)
+		return
+	}
 
+	hasStoredResponses := len(storedAuctionResponses) > 0
 	e = deps.validateRequest(req, true, hasStoredResponses, storedBidResponses, false)
 	errs = append(errs, e...)
+
 	return
 }
 
@@ -697,7 +702,7 @@ func setHeights(formats []openrtb2.Format, height int64) {
 
 // AMP won't function unless ext.prebid.targeting and ext.prebid.cache.bids are defined.
 // If the user didn't include them, default those here.
-func defaultRequestExt(req *openrtb_ext.RequestWrapper) []error {
+func initAmpTargetingAndCache(req *openrtb_ext.RequestWrapper) []error {
 	extRequest, err := req.GetRequestExt()
 	if err != nil {
 		return []error{err}
@@ -706,27 +711,23 @@ func defaultRequestExt(req *openrtb_ext.RequestWrapper) []error {
 	prebid := extRequest.GetPrebid()
 	prebidModified := false
 
-	// create prebid object if missing from request
+	// create prebid object if missing
 	if prebid == nil {
 		prebid = &openrtb_ext.ExtRequestPrebid{}
 	}
 
-	// Ensure Targeting and caching is on
+	// create targeting object if missing
 	if prebid.Targeting == nil {
-		prebid.Targeting = &openrtb_ext.ExtRequestTargeting{
-			IncludeWinners:    true,
-			IncludeBidderKeys: true,
-			PriceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
-		}
+		prebid.Targeting = &openrtb_ext.ExtRequestTargeting{}
 		prebidModified = true
 	}
 
+	// create cache object if missing
 	if prebid.Cache == nil {
-		prebid.Cache = &openrtb_ext.ExtRequestPrebidCache{
-			Bids: &openrtb_ext.ExtRequestPrebidCacheBids{},
-		}
+		prebid.Cache = &openrtb_ext.ExtRequestPrebidCache{}
 		prebidModified = true
-	} else if prebid.Cache.Bids == nil {
+	}
+	if prebid.Cache.Bids == nil {
 		prebid.Cache.Bids = &openrtb_ext.ExtRequestPrebidCacheBids{}
 		prebidModified = true
 	}

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/addtl-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/addtl-consent-through-query.json
@@ -3,12 +3,18 @@
   "query": "tag_id=101&addtl_consent=1~1.35.41.101",
   "config": {
     "mockBidders": [
-      {"bidderName": "appnexus", "currency": "USD", "price": 15}
+      {
+        "bidderName": "appnexus",
+        "currency": "USD",
+        "price": 15
+      }
     ]
   },
   "mockBidRequest": {
     "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
-    "site": {"page": "prebid.org"},
+    "site": {
+      "page": "prebid.org"
+    },
     "imp": [
       {
         "id": "/19968336/header-bid-tag-0",
@@ -32,10 +38,12 @@
     "id": "b9c97a4b-cbc4-483d-b2c4-58a19ed5cfc5",
     "site": {
       "page": "prebid.org",
-      "ext": {"amp":1}
+      "ext": {
+        "amp": 1
+      }
     },
     "device": {
-      "ip":"192.0.2.1"
+      "ip": "192.0.2.1"
     },
     "at": 1,
     "imp": [
@@ -63,11 +71,44 @@
     ],
     "user": {
       "ext": {
-        "ConsentedProvidersSettings":{"consented_providers":"1~1.35.41.101"},
-        "consented_providers_settings":{"consented_providers":[1,35,41,101]}
+        "ConsentedProvidersSettings": {
+          "consented_providers": "1~1.35.41.101"
+        },
+        "consented_providers_settings": {
+          "consented_providers": [
+            1,
+            35,
+            41,
+            101
+          ]
+        }
       }
     },
-    "ext": {"prebid":{"cache":{"bids":{"returnCreative":null},"vastxml":null},"channel":{"name":"amp","version":""},"targeting":{"pricegranularity":{"precision":2,"ranges":[{"min":0,"max":20,"increment":0.1}]},"includewinners":true,"includebidderkeys":true,"includebrandcategory":null,"includeformat":false,"durationrangesec":null,"preferdeals":false}}}
+    "ext": {
+      "prebid": {
+        "cache": {
+          "bids": {}
+        },
+        "channel": {
+          "name": "amp",
+          "version": ""
+        },
+        "targeting": {
+          "pricegranularity": {
+            "precision": 2,
+            "ranges": [
+              {
+                "min": 0,
+                "max": 20,
+                "increment": 0.1
+              }
+            ]
+          },
+          "includewinners": true,
+          "includebidderkeys": true
+        }
+      }
+    }
   },
   "expectedAmpResponse": {
     "targeting": {

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-ccpa-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-ccpa-through-query.json
@@ -81,10 +81,7 @@
     "ext": {
       "prebid": {
         "cache": {
-          "bids": {
-            "returnCreative": null
-          },
-          "vastxml": null
+          "bids": {}
         },
         "channel": {
           "name": "amp",
@@ -102,11 +99,7 @@
             ]
           },
           "includewinners": true,
-          "includebidderkeys": true,
-          "includebrandcategory": null,
-          "includeformat": false,
-          "durationrangesec": null,
-          "preferdeals": false
+          "includebidderkeys": true
         }
       }
     }

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-legacy-tcf2-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-legacy-tcf2-consent-through-query.json
@@ -86,10 +86,7 @@
     "ext": {
       "prebid": {
         "cache": {
-          "bids": {
-            "returnCreative": null
-          },
-          "vastxml": null
+          "bids": {}
         },
         "channel": {
           "name": "amp",
@@ -107,11 +104,7 @@
             ]
           },
           "includewinners": true,
-          "includebidderkeys": true,
-          "includebrandcategory": null,
-          "includeformat": false,
-          "durationrangesec": null,
-          "preferdeals": false
+          "includebidderkeys": true
         }
       }
     }

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf1-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf1-consent-through-query.json
@@ -86,10 +86,7 @@
     "ext": {
       "prebid": {
         "cache": {
-          "bids": {
-            "returnCreative": null
-          },
-          "vastxml": null
+          "bids": {}
         },
         "channel": {
           "name": "amp",
@@ -107,11 +104,7 @@
             ]
           },
           "includewinners": true,
-          "includebidderkeys": true,
-          "includebrandcategory": null,
-          "includeformat": false,
-          "durationrangesec": null,
-          "preferdeals": false
+          "includebidderkeys": true
         }
       }
     }

--- a/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf2-consent-through-query.json
+++ b/endpoints/openrtb2/sample-requests/amp/consent-through-query/gdpr-tcf2-consent-through-query.json
@@ -86,10 +86,7 @@
     "ext": {
       "prebid": {
         "cache": {
-          "bids": {
-            "returnCreative": null
-          },
-          "vastxml": null
+          "bids": {}
         },
         "channel": {
           "name": "amp",
@@ -107,11 +104,7 @@
             ]
           },
           "includewinners": true,
-          "includebidderkeys": true,
-          "includebrandcategory": null,
-          "includeformat": false,
-          "durationrangesec": null,
-          "preferdeals": false
+          "includebidderkeys": true
         }
       }
     }

--- a/endpoints/openrtb2/sample-requests/valid-whole/supplementary/req-ext-bidder-params-backward-compatible-merge.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/supplementary/req-ext-bidder-params-backward-compatible-merge.json
@@ -64,7 +64,18 @@
   "expectedReqExt": {
     "prebid": {
       "targeting": {
-        "pricegranularity": "low"
+        "pricegranularity": {
+          "precision": 2,
+          "ranges": [
+            {
+              "min": 0,
+              "max": 5,
+              "increment": 0.5
+            }
+          ]
+        },
+        "includewinners": true,
+        "includebidderkeys": true
       },
       "cache": {
         "bids": {}

--- a/endpoints/openrtb2/sample-requests/valid-whole/supplementary/req-ext-bidder-params-merge.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/supplementary/req-ext-bidder-params-merge.json
@@ -66,7 +66,18 @@
   "expectedReqExt": {
     "prebid": {
       "targeting": {
-        "pricegranularity": "low"
+        "pricegranularity": {
+          "precision": 2,
+          "ranges": [
+            {
+              "min": 0,
+              "max": 5,
+              "increment": 0.5
+            }
+          ]
+        },
+        "includewinners": true,
+        "includebidderkeys": true
       },
       "cache": {
         "bids": {}

--- a/endpoints/openrtb2/sample-requests/valid-whole/supplementary/req-ext-bidder-params.json
+++ b/endpoints/openrtb2/sample-requests/valid-whole/supplementary/req-ext-bidder-params.json
@@ -59,7 +59,18 @@
   "expectedReqExt": {
     "prebid": {
       "targeting": {
-        "pricegranularity": "low"
+        "pricegranularity": {
+          "precision": 2,
+          "ranges": [
+            {
+              "min": 0,
+              "max": 5,
+              "increment": 0.5
+            }
+          ]
+        },
+        "includewinners": true,
+        "includebidderkeys": true
       },
       "cache": {
         "bids": {}

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/prebid_cache_client"
 	"github.com/prebid/prebid-server/stored_requests/backends/empty_fetcher"
+	"github.com/prebid/prebid-server/util/ptrutil"
 
 	"github.com/prebid/openrtb/v17/adcom1"
 	"github.com/prebid/openrtb/v17/openrtb2"
 	gometrics "github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVideoEndpointImpressionsNumber(t *testing.T) {
@@ -78,7 +80,8 @@ func TestVideoEndpointImpressionsDuration(t *testing.T) {
 
 	var extData openrtb_ext.ExtRequest
 	json.Unmarshal(ex.lastRequest.Ext, &extData)
-	assert.True(t, extData.Prebid.Targeting.IncludeBidderKeys, "Request ext incorrect: IncludeBidderKeys should be true ")
+	assert.NotNil(t, extData.Prebid.Targeting.IncludeBidderKeys, "Request ext incorrect: IncludeBidderKeys should be true ")
+	assert.True(t, *extData.Prebid.Targeting.IncludeBidderKeys, "Request ext incorrect: IncludeBidderKeys should be true ")
 
 	assert.Len(t, ex.lastRequest.Imp, 22, "Incorrect number of impressions in request")
 	assert.Equal(t, ex.lastRequest.Imp[0].ID, "1_0", "Incorrect impression id in request")
@@ -121,8 +124,8 @@ func TestCreateBidExtension(t *testing.T) {
 			DurationRangeSec:     durationRange,
 			RequireExactDuration: false,
 		},
-		PriceGranularity: openrtb_ext.PriceGranularity{
-			Precision: 2,
+		PriceGranularity: &openrtb_ext.PriceGranularity{
+			Precision: ptrutil.ToPtr(2),
 			Ranges:    priceGranRanges,
 		},
 	}
@@ -138,37 +141,20 @@ func TestCreateBidExtension(t *testing.T) {
 	assert.Equal(t, resExt.Prebid.Targeting.PriceGranularity.Ranges, priceGranRanges, "Price granularity is incorrect")
 }
 
-func TestCreateBidExtensionExactDurTrueNoPriceRange(t *testing.T) {
-	durationRange := make([]int, 0)
-	durationRange = append(durationRange, 15)
-	durationRange = append(durationRange, 30)
+func TestCreateBidExtensionTargeting(t *testing.T) {
+	ex := &mockExchangeVideo{}
+	reqBody := readVideoTestFile(t, "sample-requests/video/video_valid_sample.json")
+	req := httptest.NewRequest("POST", "/openrtb2/video", strings.NewReader(reqBody))
+	recorder := httptest.NewRecorder()
 
-	translateCategories := false
-	videoRequest := openrtb_ext.BidRequestVideo{
-		IncludeBrandCategory: &openrtb_ext.IncludeBrandCategory{
-			PrimaryAdserver:     1,
-			Publisher:           "",
-			TranslateCategories: &translateCategories,
-		},
-		PodConfig: openrtb_ext.PodConfig{
-			DurationRangeSec:     durationRange,
-			RequireExactDuration: true,
-		},
-		PriceGranularity: openrtb_ext.PriceGranularity{
-			Precision: 0,
-			Ranges:    nil,
-		},
-	}
-	res, err := createBidExtension(&videoRequest)
-	assert.NoError(t, err, "Error should be nil")
+	deps := mockDeps(t, ex)
+	deps.VideoAuctionEndpoint(recorder, req, nil)
 
-	resExt := &openrtb_ext.ExtRequest{}
+	require.NotNil(t, ex.lastRequest, "The request never made it into the Exchange.")
 
-	if err := json.Unmarshal(res, &resExt); err != nil {
-		assert.Fail(t, "Unable to unmarshal bid extension")
-	}
-	assert.Equal(t, resExt.Prebid.Targeting.DurationRangeSec, []int(nil), "Duration range seconds is incorrect")
-	assert.Equal(t, resExt.Prebid.Targeting.PriceGranularity, openrtb_ext.PriceGranularityFromString("med"), "Price granularity is incorrect")
+	// assert targeting set to default
+	expectedRequestExt := `{"prebid":{"cache":{"vastxml":{}},"targeting":{"pricegranularity":{"precision":2,"ranges":[{"min":0,"max":20,"increment":0.1}]},"includebidderkeys":true,"includewinners":true,"includebrandcategory":{"primaryadserver":1,"publisher":"","withcategory":true}}}}`
+	assert.JSONEq(t, expectedRequestExt, string(ex.lastRequest.Ext))
 }
 
 func TestVideoEndpointDebugQueryTrue(t *testing.T) {
@@ -1256,13 +1242,13 @@ func (m *mockAnalyticsModule) LogVideoObject(vo *analytics.VideoObject) {
 	m.videoObjects = append(m.videoObjects, vo)
 }
 
-func (m *mockAnalyticsModule) LogCookieSyncObject(cso *analytics.CookieSyncObject) { return }
+func (m *mockAnalyticsModule) LogCookieSyncObject(cso *analytics.CookieSyncObject) {}
 
-func (m *mockAnalyticsModule) LogSetUIDObject(so *analytics.SetUIDObject) { return }
+func (m *mockAnalyticsModule) LogSetUIDObject(so *analytics.SetUIDObject) {}
 
-func (m *mockAnalyticsModule) LogAmpObject(ao *analytics.AmpObject) { return }
+func (m *mockAnalyticsModule) LogAmpObject(ao *analytics.AmpObject) {}
 
-func (m *mockAnalyticsModule) LogNotificationEventObject(ne *analytics.NotificationEvent) { return }
+func (m *mockAnalyticsModule) LogNotificationEventObject(ne *analytics.NotificationEvent) {}
 
 func mockDeps(t *testing.T, ex *mockExchangeVideo) *endpointDeps {
 	return &endpointDeps{
@@ -1369,6 +1355,10 @@ type mockExchangeVideo struct {
 }
 
 func (m *mockExchangeVideo) HoldAuction(ctx context.Context, r exchange.AuctionRequest, debugLog *exchange.DebugLog) (*openrtb2.BidResponse, error) {
+	if err := r.BidRequestWrapper.RebuildRequest(); err != nil {
+		return nil, err
+	}
+
 	m.lastRequest = r.BidRequestWrapper.BidRequest
 	if debugLog != nil && debugLog.Enabled {
 		m.cache.called = true

--- a/exchange/auction_test.go
+++ b/exchange/auction_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prebid/prebid-server/exchange/entities"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/prebid_cache_client"
+	"github.com/prebid/prebid-server/util/ptrutil"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -229,7 +230,7 @@ func runCacheSpec(t *testing.T, fileDisplayName string, specData *cacheSpec) {
 
 	targData := &targetData{
 		priceGranularity: openrtb_ext.PriceGranularity{
-			Precision: 2,
+			Precision: ptrutil.ToPtr(2),
 			Ranges: []openrtb_ext.GranularityRange{
 				{
 					Min:       0,

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prebid/prebid-server/hooks"
 	"github.com/prebid/prebid-server/hooks/hookexecution"
 	"github.com/prebid/prebid-server/hooks/hookstage"
+	"github.com/prebid/prebid-server/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
@@ -2142,7 +2143,7 @@ func TestExchangeJSON(t *testing.T) {
 			t.Run(fileDisplayName, func(t *testing.T) {
 				specData, err := loadFile(fileName)
 				if assert.NoError(t, err, "Failed to load contents of file %s: %v", fileDisplayName, err) {
-					runSpec(t, fileDisplayName, specData)
+					assert.NotPanics(t, func() { runSpec(t, fileDisplayName, specData) }, fileDisplayName)
 				}
 			})
 		}
@@ -2508,7 +2509,7 @@ func (m *fakeRandomDeduplicateBidBooleanGenerator) Generate() bool {
 
 func newExtRequest() openrtb_ext.ExtRequest {
 	priceGran := openrtb_ext.PriceGranularity{
-		Precision: 2,
+		Precision: ptrutil.ToPtr(2),
 		Ranges: []openrtb_ext.GranularityRange{
 			{
 				Min:       0.0,
@@ -2522,8 +2523,8 @@ func newExtRequest() openrtb_ext.ExtRequest {
 	brandCat := openrtb_ext.ExtIncludeBrandCategory{PrimaryAdServer: 1, WithCategory: true, TranslateCategories: &translateCategories}
 
 	reqExt := openrtb_ext.ExtRequestTargeting{
-		PriceGranularity:     priceGran,
-		IncludeWinners:       true,
+		PriceGranularity:     &priceGran,
+		IncludeWinners:       ptrutil.ToPtr(true),
 		IncludeBrandCategory: &brandCat,
 	}
 
@@ -2536,7 +2537,7 @@ func newExtRequest() openrtb_ext.ExtRequest {
 
 func newExtRequestNoBrandCat() openrtb_ext.ExtRequest {
 	priceGran := openrtb_ext.PriceGranularity{
-		Precision: 2,
+		Precision: ptrutil.ToPtr(2),
 		Ranges: []openrtb_ext.GranularityRange{
 			{
 				Min:       0.0,
@@ -2549,8 +2550,8 @@ func newExtRequestNoBrandCat() openrtb_ext.ExtRequest {
 	brandCat := openrtb_ext.ExtIncludeBrandCategory{WithCategory: false}
 
 	reqExt := openrtb_ext.ExtRequestTargeting{
-		PriceGranularity:     priceGran,
-		IncludeWinners:       true,
+		PriceGranularity:     &priceGran,
+		IncludeWinners:       ptrutil.ToPtr(true),
 		IncludeBrandCategory: &brandCat,
 	}
 
@@ -2571,7 +2572,7 @@ func TestCategoryMapping(t *testing.T) {
 	requestExt := newExtRequest()
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -2627,7 +2628,7 @@ func TestCategoryMappingNoIncludeBrandCategory(t *testing.T) {
 	requestExt := newExtRequestNoBrandCat()
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 	requestExt.Prebid.Targeting.DurationRangeSec = []int{15, 30, 40, 50}
@@ -2682,7 +2683,7 @@ func TestCategoryMappingTranslateCategoriesNil(t *testing.T) {
 	requestExt := newExtRequestTranslateCategories(nil)
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -2725,7 +2726,7 @@ func TestCategoryMappingTranslateCategoriesNil(t *testing.T) {
 
 func newExtRequestTranslateCategories(translateCategories *bool) openrtb_ext.ExtRequest {
 	priceGran := openrtb_ext.PriceGranularity{
-		Precision: 2,
+		Precision: ptrutil.ToPtr(2),
 		Ranges: []openrtb_ext.GranularityRange{
 			{
 				Min:       0.0,
@@ -2741,8 +2742,8 @@ func newExtRequestTranslateCategories(translateCategories *bool) openrtb_ext.Ext
 	}
 
 	reqExt := openrtb_ext.ExtRequestTargeting{
-		PriceGranularity:     priceGran,
-		IncludeWinners:       true,
+		PriceGranularity:     &priceGran,
+		IncludeWinners:       ptrutil.ToPtr(true),
 		IncludeBrandCategory: &brandCat,
 	}
 
@@ -2764,7 +2765,7 @@ func TestCategoryMappingTranslateCategoriesFalse(t *testing.T) {
 	requestExt := newExtRequestTranslateCategories(&translateCategories)
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -2815,7 +2816,7 @@ func TestCategoryDedupe(t *testing.T) {
 	requestExt := newExtRequest()
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -2895,7 +2896,7 @@ func TestNoCategoryDedupe(t *testing.T) {
 	requestExt := newExtRequestNoBrandCat()
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -2977,7 +2978,7 @@ func TestCategoryMappingBidderName(t *testing.T) {
 	requestExt.Prebid.Targeting.AppendBidderNames = true
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -3031,7 +3032,7 @@ func TestCategoryMappingBidderNameNoCategories(t *testing.T) {
 	requestExt.Prebid.Targeting.AppendBidderNames = true
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -3084,7 +3085,7 @@ func TestBidRejectionErrors(t *testing.T) {
 	requestExt.Prebid.Targeting.DurationRangeSec = []int{15, 30, 50}
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -3191,7 +3192,7 @@ func TestCategoryMappingTwoBiddersOneBidEachNoCategorySamePrice(t *testing.T) {
 	requestExt := newExtRequestTranslateCategories(nil)
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 
@@ -3268,7 +3269,7 @@ func TestCategoryMappingTwoBiddersManyBidsEachNoCategorySamePrice(t *testing.T) 
 	requestExt := newExtRequestTranslateCategories(nil)
 
 	targData := &targetData{
-		priceGranularity: requestExt.Prebid.Targeting.PriceGranularity,
+		priceGranularity: *requestExt.Prebid.Targeting.PriceGranularity,
 		includeWinners:   true,
 	}
 

--- a/exchange/exchangetest/append-bidder-names.json
+++ b/exchange/exchangetest/append-bidder-names.json
@@ -50,6 +50,18 @@
               "publisher": "",
               "withcategory": true
             },
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "appendbiddernames": true
           }
         }
@@ -229,6 +241,18 @@
                   "publisher": "",
                   "withcategory": true
                 },
+                "pricegranularity": {
+                  "precision": 2,
+                  "ranges": [
+                    {
+                      "min": 0,
+                      "max": 20,
+                      "increment": 0.1
+                    }
+                  ]
+                },
+                "includewinners": true,
+                "includebidderkeys": true,
                 "appendbiddernames": true
               }
             }

--- a/exchange/exchangetest/bid-id-invalid.json
+++ b/exchange/exchangetest/bid-id-invalid.json
@@ -37,6 +37,18 @@
               "publisher": "",
               "withcategory": true
             },
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "appendbiddernames": true
           }
         }
@@ -154,6 +166,18 @@
                   "publisher": "",
                   "withcategory": true
                 },
+                "pricegranularity": {
+                  "precision": 2,
+                  "ranges": [
+                    {
+                      "min": 0,
+                      "max": 20,
+                      "increment": 0.1
+                    }
+                  ]
+                },
+                "includewinners": true,
+                "includebidderkeys": true,
                 "appendbiddernames": true
               }
             }

--- a/exchange/exchangetest/bid-id-valid.json
+++ b/exchange/exchangetest/bid-id-valid.json
@@ -37,6 +37,18 @@
               "publisher": "",
               "withcategory": true
             },
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "appendbiddernames": true
           }
         }
@@ -150,6 +162,18 @@
           "ext": {
             "prebid": {
               "targeting": {
+                "pricegranularity": {
+                  "precision": 2,
+                  "ranges": [
+                    {
+                      "min": 0,
+                      "max": 20,
+                      "increment": 0.1
+                    }
+                  ]
+                },
+                "includewinners": true,
+                "includebidderkeys": true,
                 "includebrandcategory": {
                   "primaryadserver": 1,
                   "publisher": "",

--- a/exchange/exchangetest/debuglog_disabled.json
+++ b/exchange/exchangetest/debuglog_disabled.json
@@ -55,6 +55,18 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "includebrandcategory": {
               "primaryadserver": 1,
               "publisher": "",
@@ -233,6 +245,18 @@
           "ext": {
             "prebid": {
               "targeting": {
+                "pricegranularity": {
+                  "precision": 2,
+                  "ranges": [
+                    {
+                      "min": 0,
+                      "max": 20,
+                      "increment": 0.1
+                    }
+                  ]
+                },
+                "includewinners": true,
+                "includebidderkeys": true,
                 "includebrandcategory": {
                   "primaryadserver": 1,
                   "publisher": "",

--- a/exchange/exchangetest/debuglog_enabled.json
+++ b/exchange/exchangetest/debuglog_enabled.json
@@ -57,6 +57,18 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "includebrandcategory": {
               "primaryadserver": 1,
               "publisher": "",
@@ -235,6 +247,18 @@
           "ext": {
             "prebid": {
               "targeting": {
+                "pricegranularity": {
+                  "precision": 2,
+                  "ranges": [
+                    {
+                      "min": 0,
+                      "max": 20,
+                      "increment": 0.1
+                    }
+                  ]
+                },
+                "includewinners": true,
+                "includebidderkeys": true,
                 "includebrandcategory": {
                   "primaryadserver": 1,
                   "publisher": "",

--- a/exchange/exchangetest/debuglog_enabled_no_bids.json
+++ b/exchange/exchangetest/debuglog_enabled_no_bids.json
@@ -56,6 +56,18 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": false,
+            "includebidderkeys": true,
             "includebrandcategory": {
               "primaryadserver": 1,
               "publisher": "",

--- a/exchange/exchangetest/events-vast-account-off-request-off.json
+++ b/exchange/exchangetest/events-vast-account-off-request-off.json
@@ -29,7 +29,17 @@
         "prebid": {
           "targeting": {
             "includewinners": true,
-            "includebidderkeys": false
+            "includebidderkeys": false,
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            }
           }
         }
       }

--- a/exchange/exchangetest/events-vast-account-off-request-on.json
+++ b/exchange/exchangetest/events-vast-account-off-request-on.json
@@ -32,6 +32,16 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
             "includewinners": true,
             "includebidderkeys": false
           },

--- a/exchange/exchangetest/events-vast-account-on-request-off.json
+++ b/exchange/exchangetest/events-vast-account-on-request-off.json
@@ -28,6 +28,16 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
             "includewinners": true,
             "includebidderkeys": false
           },

--- a/exchange/exchangetest/extra-bids-with-aliases-adaptercode.json
+++ b/exchange/exchangetest/extra-bids-with-aliases-adaptercode.json
@@ -44,6 +44,16 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
             "includewinners": true,
             "includebidderkeys": true
           },

--- a/exchange/exchangetest/extra-bids.json
+++ b/exchange/exchangetest/extra-bids.json
@@ -50,6 +50,16 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
             "includewinners": true,
             "includebidderkeys": true
           },

--- a/exchange/exchangetest/include-brand-category.json
+++ b/exchange/exchangetest/include-brand-category.json
@@ -44,6 +44,18 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "includebrandcategory": {
               "primaryadserver": 1,
               "publisher": "",

--- a/exchange/exchangetest/request-multi-bidders-debug-info.json
+++ b/exchange/exchangetest/request-multi-bidders-debug-info.json
@@ -55,6 +55,18 @@
               15,
               30
             ],
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "includebrandcategory": {
               "primaryadserver": 1,
               "publisher": "",
@@ -249,6 +261,18 @@
                   15,
                   30
                 ],
+                "pricegranularity": {
+                  "precision": 2,
+                  "ranges": [
+                    {
+                      "min": 0,
+                      "max": 20,
+                      "increment": 0.1
+                    }
+                  ]
+                },
+                "includewinners": true,
+                "includebidderkeys": true,
                 "includebrandcategory": {
                   "primaryadserver": 1,
                   "publisher": "",

--- a/exchange/exchangetest/request-multi-bidders-one-no-resp.json
+++ b/exchange/exchangetest/request-multi-bidders-one-no-resp.json
@@ -54,6 +54,18 @@
               15,
               30
             ],
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true,
             "includebrandcategory": {
               "primaryadserver": 1,
               "publisher": "",

--- a/exchange/exchangetest/targeting-cache-vast-banner.json
+++ b/exchange/exchangetest/targeting-cache-vast-banner.json
@@ -28,7 +28,20 @@
           "cache": {
             "vastxml": {}
           },
-          "targeting": {}
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true
+          }
         }
       }
     }

--- a/exchange/exchangetest/targeting-cache-vast.json
+++ b/exchange/exchangetest/targeting-cache-vast.json
@@ -29,7 +29,20 @@
           "cache": {
             "vastxml": {}
           },
-          "targeting": {}
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includebidderkeys": true,
+            "includewinners": true
+          }
         }
       }
     }

--- a/exchange/exchangetest/targeting-cache-zero.json
+++ b/exchange/exchangetest/targeting-cache-zero.json
@@ -31,7 +31,20 @@
             "bids": {},
             "vastxml": {}
           },
-          "targeting": {}
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true
+          }
         }
       }
     }

--- a/exchange/exchangetest/targeting-mobile.json
+++ b/exchange/exchangetest/targeting-mobile.json
@@ -49,7 +49,20 @@
       ],
       "ext": {
         "prebid": {
-          "targeting": {}
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true
+          }
         }
       }
     }

--- a/exchange/exchangetest/targeting-no-winners.json
+++ b/exchange/exchangetest/targeting-no-winners.json
@@ -50,7 +50,18 @@
       "ext": {
         "prebid": {
           "targeting": {
-            "includewinners": false
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": false,
+            "includebidderkeys": true
           }
         }
       }

--- a/exchange/exchangetest/targeting-only-winners.json
+++ b/exchange/exchangetest/targeting-only-winners.json
@@ -50,6 +50,17 @@
       "ext": {
         "prebid": {
           "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
             "includebidderkeys": false
           }
         }

--- a/exchange/exchangetest/targeting-with-winners.json
+++ b/exchange/exchangetest/targeting-with-winners.json
@@ -49,7 +49,20 @@
       ],
       "ext": {
         "prebid": {
-          "targeting": {}
+          "targeting": {
+            "pricegranularity": {
+              "precision": 2,
+              "ranges": [
+                {
+                  "min": 0,
+                  "max": 20,
+                  "increment": 0.1
+                }
+              ]
+            },
+            "includewinners": true,
+            "includebidderkeys": true
+          }
         }
       }
     }

--- a/exchange/price_granularity.go
+++ b/exchange/price_granularity.go
@@ -11,9 +11,10 @@ import (
 func GetPriceBucket(cpm float64, config openrtb_ext.PriceGranularity) string {
 	cpmStr := ""
 	bucketMax := 0.0
-	increment := 0.0
-	precision := config.Precision
 	bucketMin := 0.0
+	increment := 0.0
+	precision := *config.Precision
+
 	for i := 0; i < len(config.Ranges); i++ {
 		if config.Ranges[i].Max > bucketMax {
 			bucketMax = config.Ranges[i].Max

--- a/exchange/targeting_test.go
+++ b/exchange/targeting_test.go
@@ -158,13 +158,13 @@ func buildAdapterMap(bids map[openrtb_ext.BidderName][]*openrtb2.Bid, mockServer
 func buildTargetingExt(includeCache bool, includeWinners bool, includeBidderKeys bool) json.RawMessage {
 	var targeting string
 	if includeWinners && includeBidderKeys {
-		targeting = "{}"
+		targeting = `{"pricegranularity":{"precision":2,"ranges": [{"min": 0,"max": 20,"increment": 0.1}]},"includewinners": true, "includebidderkeys": true}`
 	} else if !includeWinners && includeBidderKeys {
-		targeting = `{"includewinners": false}`
+		targeting = `{"precision":2,"includewinners": false}`
 	} else if includeWinners && !includeBidderKeys {
-		targeting = `{"includebidderkeys": false}`
+		targeting = `{"precision":2,"includebidderkeys": false}`
 	} else {
-		targeting = `{"includewinners": false, "includebidderkeys": false}`
+		targeting = `{"precision":2,"includewinners": false, "includebidderkeys": false}`
 	}
 
 	if includeCache {
@@ -286,15 +286,23 @@ var bid084 *openrtb2.Bid = &openrtb2.Bid{
 	Price: 0.84,
 }
 
-var truncateTargetAttrValue10 int = 10
-var truncateTargetAttrValue5 int = 5
-var truncateTargetAttrValue25 int = 25
-var truncateTargetAttrValueNegative int = -1
+var (
+	truncateTargetAttrValue10       int = 10
+	truncateTargetAttrValue5        int = 5
+	truncateTargetAttrValue25       int = 25
+	truncateTargetAttrValueNegative int = -1
+)
+
+func lookupPriceGranularity(v string) openrtb_ext.PriceGranularity {
+	priceGranularity, _ := openrtb_ext.NewPriceGranularityFromLegacyID(v)
+	return priceGranularity
+}
+
 var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Targeting winners only (most basic targeting example)",
 		TargetData: targetData{
-			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
 		},
 		Auction: auction{
@@ -325,7 +333,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Targeting on bidders only",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
 		},
 		Auction: auction{
@@ -359,7 +367,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Full basic targeting with hd_format",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeWinners:    true,
 			includeBidderKeys: true,
 			includeFormat:     true,
@@ -400,7 +408,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Cache and deal targeting test",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
 			cacheHost:         "cache.prebid.com",
 			cachePath:         "cache",
@@ -447,7 +455,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "bidder with no dealID should not have deal targeting",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
 		},
 		Auction: auction{
@@ -473,7 +481,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Truncate Targeting Attribute value is given and is less than const MaxKeyLength",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
 		},
 		Auction: auction{
@@ -507,7 +515,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Truncate Targeting Attribute value is given and is greater than const MaxKeyLength",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
 		},
 		Auction: auction{
@@ -541,7 +549,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Truncate Targeting Attribute value is given and is negative",
 		TargetData: targetData{
-			priceGranularity:  openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity:  lookupPriceGranularity("med"),
 			includeBidderKeys: true,
 		},
 		Auction: auction{
@@ -575,7 +583,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Check that key gets truncated properly when value is smaller than key",
 		TargetData: targetData{
-			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
 		},
 		Auction: auction{
@@ -606,7 +614,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Check that key gets truncated properly when value is greater than key",
 		TargetData: targetData{
-			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
 		},
 		Auction: auction{
@@ -637,7 +645,7 @@ var TargetingTests []TargetingTestData = []TargetingTestData{
 	{
 		Description: "Check that key gets truncated properly when value is negative",
 		TargetData: targetData{
-			priceGranularity: openrtb_ext.PriceGranularityFromString("med"),
+			priceGranularity: lookupPriceGranularity("med"),
 			includeWinners:   true,
 		},
 		Auction: auction{

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -731,12 +731,12 @@ func getExtTargetData(requestExt *openrtb_ext.ExtRequest, cacheInstructions *ext
 
 	if requestExt != nil && requestExt.Prebid.Targeting != nil {
 		targData = &targetData{
-			priceGranularity:  requestExt.Prebid.Targeting.PriceGranularity,
-			includeWinners:    requestExt.Prebid.Targeting.IncludeWinners,
-			includeBidderKeys: requestExt.Prebid.Targeting.IncludeBidderKeys,
+			includeWinners:    *requestExt.Prebid.Targeting.IncludeWinners,
+			includeBidderKeys: *requestExt.Prebid.Targeting.IncludeBidderKeys,
 			includeCacheBids:  cacheInstructions.cacheBids,
 			includeCacheVast:  cacheInstructions.cacheVAST,
 			includeFormat:     requestExt.Prebid.Targeting.IncludeFormat,
+			priceGranularity:  *requestExt.Prebid.Targeting.PriceGranularity,
 			preferDeals:       requestExt.Prebid.Targeting.PreferDeals,
 		}
 	}

--- a/exchange/utils_test.go
+++ b/exchange/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prebid/prebid-server/gdpr"
 	"github.com/prebid/prebid-server/metrics"
 	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -1756,12 +1757,12 @@ func TestGetExtTargetData(t *testing.T) {
 				requestExt: &openrtb_ext.ExtRequest{
 					Prebid: openrtb_ext.ExtRequestPrebid{
 						Targeting: &openrtb_ext.ExtRequestTargeting{
-							PriceGranularity: openrtb_ext.PriceGranularity{
-								Precision: 2,
+							PriceGranularity: &openrtb_ext.PriceGranularity{
+								Precision: ptrutil.ToPtr(2),
 								Ranges:    []openrtb_ext.GranularityRange{{Min: 0.00, Max: 5.00, Increment: 1.00}},
 							},
-							IncludeWinners:    true,
-							IncludeBidderKeys: true,
+							IncludeWinners:    ptrutil.ToPtr(true),
+							IncludeBidderKeys: ptrutil.ToPtr(true),
 						},
 					},
 				},
@@ -1773,7 +1774,7 @@ func TestGetExtTargetData(t *testing.T) {
 			outTest{
 				targetData: &targetData{
 					priceGranularity: openrtb_ext.PriceGranularity{
-						Precision: 2,
+						Precision: ptrutil.ToPtr(2),
 						Ranges:    []openrtb_ext.GranularityRange{{Min: 0.00, Max: 5.00, Increment: 1.00}},
 					},
 					includeWinners:    true,

--- a/macros/macros.go
+++ b/macros/macros.go
@@ -21,6 +21,8 @@ type UserSyncTemplateParams struct {
 	GDPR        string
 	GDPRConsent string
 	USPrivacy   string
+	GPP         string
+	GPPSID      string
 }
 
 // ResolveMacros resolves macros in the given template with the provided params

--- a/openrtb_ext/bid_request_video.go
+++ b/openrtb_ext/bid_request_video.go
@@ -98,7 +98,7 @@ type BidRequestVideo struct {
 	//   object; optional
 	// Description:
 	//    Object to tell ad server how much money the “bidder” demand is worth to you
-	PriceGranularity PriceGranularity `json:"pricegranularity,omitempty"`
+	PriceGranularity *PriceGranularity `json:"pricegranularity,omitempty"`
 
 	// Attribute:
 	//   tmax

--- a/openrtb_ext/request_wrapper.go
+++ b/openrtb_ext/request_wrapper.go
@@ -712,7 +712,7 @@ func (re *RequestExt) SetExt(ext map[string]json.RawMessage) {
 }
 
 func (re *RequestExt) GetPrebid() *ExtRequestPrebid {
-	if re.prebid == nil {
+	if re == nil || re.prebid == nil {
 		return nil
 	}
 	prebid := *re.prebid

--- a/ortb/default.go
+++ b/ortb/default.go
@@ -1,0 +1,87 @@
+package ortb
+
+import (
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/util/ptrutil"
+)
+
+const (
+	DefaultPriceGranularityPrecision  = 2
+	DefaultTargetingIncludeWinners    = true
+	DefaultTargetingIncludeBidderKeys = true
+)
+
+func SetDefaults(r *openrtb_ext.RequestWrapper) error {
+	requestExt, err := r.GetRequestExt()
+	if err != nil {
+		return err
+	}
+
+	requestExtPrebid := requestExt.GetPrebid()
+	if requestExtPrebid != nil {
+		modified := setDefaultsTargeting(requestExtPrebid.Targeting)
+
+		if modified {
+			requestExt.SetPrebid(requestExtPrebid)
+		}
+	}
+
+	return nil
+}
+
+func setDefaultsTargeting(targeting *openrtb_ext.ExtRequestTargeting) bool {
+	if targeting == nil {
+		return false
+	}
+
+	modified := false
+
+	if targeting.PriceGranularity == nil || len(targeting.PriceGranularity.Ranges) == 0 {
+		targeting.PriceGranularity = ptrutil.ToPtr(openrtb_ext.NewPriceGranularityDefault())
+		modified = true
+	} else if setDefaultsPriceGranularity(targeting.PriceGranularity) {
+		modified = true
+	}
+
+	if targeting.IncludeWinners == nil {
+		targeting.IncludeWinners = ptrutil.ToPtr(DefaultTargetingIncludeWinners)
+		modified = true
+	}
+
+	if targeting.IncludeBidderKeys == nil {
+		targeting.IncludeBidderKeys = ptrutil.ToPtr(DefaultTargetingIncludeBidderKeys)
+		modified = true
+	}
+
+	return modified
+}
+
+func setDefaultsPriceGranularity(pg *openrtb_ext.PriceGranularity) bool {
+	modified := false
+
+	if pg.Precision == nil {
+		pg.Precision = ptrutil.ToPtr(DefaultPriceGranularityPrecision)
+		modified = true
+	}
+
+	if setDefaultsPriceGranularityRange(pg.Ranges) {
+		modified = true
+	}
+
+	return modified
+}
+
+func setDefaultsPriceGranularityRange(ranges []openrtb_ext.GranularityRange) bool {
+	modified := false
+
+	var prevMax float64 = 0
+	for i, r := range ranges {
+		if ranges[i].Min != prevMax {
+			ranges[i].Min = prevMax
+			modified = true
+		}
+		prevMax = r.Max
+	}
+
+	return modified
+}

--- a/ortb/default_test.go
+++ b/ortb/default_test.go
@@ -1,0 +1,331 @@
+package ortb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prebid/openrtb/v17/openrtb2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"github.com/prebid/prebid-server/util/ptrutil"
+)
+
+func TestSetDefaults(t *testing.T) {
+	testCases := []struct {
+		name            string
+		givenRequest    openrtb2.BidRequest
+		expectedRequest openrtb2.BidRequest
+		expectedErr     string
+	}{
+		{
+			name:            "empty",
+			givenRequest:    openrtb2.BidRequest{},
+			expectedRequest: openrtb2.BidRequest{},
+		},
+		{
+			name:            "malformed request.ext",
+			givenRequest:    openrtb2.BidRequest{Ext: json.RawMessage(`malformed`)},
+			expectedRequest: openrtb2.BidRequest{Ext: json.RawMessage(`malformed`)},
+			expectedErr:     "invalid character 'm' looking for beginning of value",
+		},
+		{
+			name:            "targeting", // tests integration with setDefaultsTargeting
+			givenRequest:    openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"targeting":{}}}`)},
+			expectedRequest: openrtb2.BidRequest{Ext: json.RawMessage(`{"prebid":{"targeting":{"pricegranularity":{"precision":2,"ranges":[{"min":0,"max":20,"increment":0.1}]},"includewinners":true,"includebidderkeys":true}}}`)},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			wrapper := &openrtb_ext.RequestWrapper{BidRequest: &test.givenRequest}
+
+			// run
+			err := SetDefaults(wrapper)
+
+			// assert error
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "Error")
+			}
+
+			// rebuild request
+			require.NoError(t, wrapper.RebuildRequest(), "Rebuild Request")
+
+			// assert
+			if len(test.expectedErr) > 0 {
+				assert.EqualError(t, err, test.expectedErr, "Error")
+				assert.Equal(t, &test.expectedRequest, wrapper.BidRequest, "Request")
+			} else {
+				// assert request as json to ignore order in ext fields
+				expectedRequestJSON, err := json.Marshal(test.expectedRequest)
+				require.NoError(t, err, "Marshal Expected Request")
+
+				actualRequestJSON, err := json.Marshal(wrapper.BidRequest)
+				require.NoError(t, err, "Marshal Actual Request")
+
+				assert.JSONEq(t, string(expectedRequestJSON), string(actualRequestJSON), "Request")
+			}
+		})
+	}
+}
+
+func TestSetDefaultsTargeting(t *testing.T) {
+	defaultGranularity := openrtb_ext.PriceGranularity{
+		Precision: ptrutil.ToPtr(DefaultPriceGranularityPrecision),
+		Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 20, Increment: 0.1}},
+	}
+
+	testCases := []struct {
+		name              string
+		givenTargeting    *openrtb_ext.ExtRequestTargeting
+		expectedTargeting *openrtb_ext.ExtRequestTargeting
+		expectedModified  bool
+	}{
+		{
+			name:              "nil",
+			givenTargeting:    nil,
+			expectedTargeting: nil,
+		},
+		{
+			name:           "empty-targeting",
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity:  &defaultGranularity,
+				IncludeWinners:    ptrutil.ToPtr(DefaultTargetingIncludeWinners),
+				IncludeBidderKeys: ptrutil.ToPtr(DefaultTargetingIncludeBidderKeys),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "populated-partial", // precision and includewinners defaults set
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Ranges: []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+				},
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(DefaultPriceGranularityPrecision),
+					Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+				},
+				IncludeWinners:    ptrutil.ToPtr(DefaultTargetingIncludeWinners),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "populated-no-granularity",
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity:  &openrtb_ext.PriceGranularity{},
+				IncludeWinners:    ptrutil.ToPtr(false),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity:  &defaultGranularity,
+				IncludeWinners:    ptrutil.ToPtr(false),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "populated-ranges-nil",
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(4),
+					Ranges:    nil,
+				},
+			},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity:  &defaultGranularity,
+				IncludeWinners:    ptrutil.ToPtr(DefaultTargetingIncludeWinners),
+				IncludeBidderKeys: ptrutil.ToPtr(DefaultTargetingIncludeBidderKeys),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "populated-ranges-empty",
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(4),
+					Ranges:    []openrtb_ext.GranularityRange{},
+				},
+			},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity:  &defaultGranularity,
+				IncludeWinners:    ptrutil.ToPtr(DefaultTargetingIncludeWinners),
+				IncludeBidderKeys: ptrutil.ToPtr(DefaultTargetingIncludeBidderKeys),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "populated-full", // no defaults set
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(4),
+					Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+				},
+				IncludeWinners:    ptrutil.ToPtr(false),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(4),
+					Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+				},
+				IncludeWinners:    ptrutil.ToPtr(false),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "setDefaultsPriceGranularity-integration",
+			givenTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(4),
+					Ranges:    []openrtb_ext.GranularityRange{{Min: 5, Max: 10, Increment: 1}},
+				},
+				IncludeWinners:    ptrutil.ToPtr(false),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedTargeting: &openrtb_ext.ExtRequestTargeting{
+				PriceGranularity: &openrtb_ext.PriceGranularity{
+					Precision: ptrutil.ToPtr(4),
+					Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+				},
+				IncludeWinners:    ptrutil.ToPtr(false),
+				IncludeBidderKeys: ptrutil.ToPtr(false),
+			},
+			expectedModified: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualModified := setDefaultsTargeting(test.givenTargeting)
+			assert.Equal(t, test.expectedModified, actualModified)
+			assert.Equal(t, test.expectedTargeting, test.givenTargeting)
+		})
+	}
+}
+
+func TestSetDefaultsPriceGranularity(t *testing.T) {
+	testCases := []struct {
+		name                string
+		givenGranularity    *openrtb_ext.PriceGranularity
+		expectedGranularity *openrtb_ext.PriceGranularity
+		expectedModified    bool
+	}{
+		{
+			name: "no-precision",
+			givenGranularity: &openrtb_ext.PriceGranularity{
+				Precision: nil,
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			},
+			expectedGranularity: &openrtb_ext.PriceGranularity{
+				Precision: ptrutil.ToPtr(2),
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			},
+			expectedModified: true,
+		},
+		{
+			name: "incomplete-range",
+			givenGranularity: &openrtb_ext.PriceGranularity{
+				Precision: ptrutil.ToPtr(2),
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 5, Max: 10, Increment: 1}},
+			},
+			expectedGranularity: &openrtb_ext.PriceGranularity{
+				Precision: ptrutil.ToPtr(2),
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			},
+			expectedModified: true,
+		},
+		{
+			name: "no-precision+incomplete-range",
+			givenGranularity: &openrtb_ext.PriceGranularity{
+				Precision: nil,
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 5, Max: 10, Increment: 1}},
+			},
+			expectedGranularity: &openrtb_ext.PriceGranularity{
+				Precision: ptrutil.ToPtr(2),
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			},
+			expectedModified: true,
+		},
+		{
+			name: "all-set",
+			givenGranularity: &openrtb_ext.PriceGranularity{
+				Precision: ptrutil.ToPtr(2),
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			},
+			expectedGranularity: &openrtb_ext.PriceGranularity{
+				Precision: ptrutil.ToPtr(2),
+				Ranges:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			},
+			expectedModified: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualModified := setDefaultsPriceGranularity(test.givenGranularity)
+			assert.Equal(t, test.expectedModified, actualModified)
+			assert.Equal(t, test.expectedGranularity, test.givenGranularity)
+		})
+	}
+}
+
+func TestSetDefaultsPriceGranularityRange(t *testing.T) {
+	testCases := []struct {
+		name             string
+		givenRange       []openrtb_ext.GranularityRange
+		expectedRange    []openrtb_ext.GranularityRange
+		expectedModified bool
+	}{
+		{
+			name:             "nil",
+			givenRange:       nil,
+			expectedRange:    nil,
+			expectedModified: false,
+		},
+		{
+			name:             "empty",
+			givenRange:       []openrtb_ext.GranularityRange{},
+			expectedRange:    []openrtb_ext.GranularityRange{},
+			expectedModified: false,
+		},
+		{
+			name:             "one-ok",
+			givenRange:       []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			expectedRange:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			expectedModified: false,
+		},
+		{
+			name:             "one-fixed",
+			givenRange:       []openrtb_ext.GranularityRange{{Min: 5, Max: 10, Increment: 1}},
+			expectedRange:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}},
+			expectedModified: true,
+		},
+		{
+			name:             "many-ok",
+			givenRange:       []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}, {Min: 10, Max: 20, Increment: 1}},
+			expectedRange:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}, {Min: 10, Max: 20, Increment: 1}},
+			expectedModified: false,
+		},
+		{
+			name:             "many-fixed",
+			givenRange:       []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}, {Min: 15, Max: 20, Increment: 1}},
+			expectedRange:    []openrtb_ext.GranularityRange{{Min: 0, Max: 10, Increment: 1}, {Min: 10, Max: 20, Increment: 1}},
+			expectedModified: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualModified := setDefaultsPriceGranularityRange(test.givenRange)
+			assert.Equal(t, test.expectedModified, actualModified)
+			assert.Equal(t, test.expectedRange, test.givenRange)
+		})
+	}
+}

--- a/privacy/gpp/gpp.go
+++ b/privacy/gpp/gpp.go
@@ -1,0 +1,8 @@
+package gpp
+
+// Policy represents the GPP privacy string container.
+// Currently just a placeholder until more expansive support is made.
+type Policy struct {
+	Consent string
+	RawSID  string // This is the CSV format ("2,6") that the IAB recommends for passing the SID(s) on a query string.
+}

--- a/privacy/policies.go
+++ b/privacy/policies.go
@@ -3,6 +3,7 @@ package privacy
 import (
 	"github.com/prebid/prebid-server/privacy/ccpa"
 	"github.com/prebid/prebid-server/privacy/gdpr"
+	"github.com/prebid/prebid-server/privacy/gpp"
 	"github.com/prebid/prebid-server/privacy/lmt"
 )
 
@@ -11,4 +12,5 @@ type Policies struct {
 	CCPA ccpa.Policy
 	GDPR gdpr.Policy
 	LMT  lmt.Policy
+	GPP  gpp.Policy
 }

--- a/static/bidder-info/beyondmedia.yaml
+++ b/static/bidder-info/beyondmedia.yaml
@@ -13,3 +13,7 @@ capabilities:
     - banner
     - video
     - native
+userSync:
+  redirect:
+    url: "https://cookies.andbeyond.media/pbserver?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/usersync/syncer.go
+++ b/usersync/syncer.go
@@ -229,6 +229,8 @@ func (s standardSyncer) GetSync(syncTypes []SyncType, privacyPolicies privacy.Po
 		GDPR:        privacyPolicies.GDPR.Signal,
 		GDPRConsent: privacyPolicies.GDPR.Consent,
 		USPrivacy:   privacyPolicies.CCPA.Consent,
+		GPP:         privacyPolicies.GPP.Consent,
+		GPPSID:      privacyPolicies.GPP.RawSID,
 	})
 	if err != nil {
 		return Sync{}, err

--- a/usersync/syncer_test.go
+++ b/usersync/syncer_test.go
@@ -177,7 +177,7 @@ func TestBuildTemplate(t *testing.T) {
 		key           = "anyKey"
 		syncTypeValue = "x"
 		hostConfig    = config.UserSync{ExternalURL: "http://host.com", RedirectURL: "{{.ExternalURL}}/host"}
-		macroValues   = macros.UserSyncTemplateParams{GDPR: "A", GDPRConsent: "B", USPrivacy: "C"}
+		macroValues   = macros.UserSyncTemplateParams{GDPR: "A", GDPRConsent: "B", USPrivacy: "C", GPP: "D", GPPSID: "1"}
 	)
 
 	testCases := []struct {
@@ -199,11 +199,11 @@ func TestBuildTemplate(t *testing.T) {
 			description: "All Composed Macros",
 			givenSyncerEndpoint: config.SyncerEndpoint{
 				URL:         "https://bidder.com/sync?redirect={{.RedirectURL}}",
-				RedirectURL: "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&f={{.SyncType}}&gdpr={{.GDPR}}&uid={{.UserMacro}}",
+				RedirectURL: "{{.ExternalURL}}/setuid?bidder={{.SyncerKey}}&f={{.SyncType}}&gdpr={{.GDPR}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&uid={{.UserMacro}}",
 				ExternalURL: "http://syncer.com",
 				UserMacro:   "$UID$",
 			},
-			expectedRendered: "https://bidder.com/sync?redirect=http%3A%2F%2Fsyncer.com%2Fsetuid%3Fbidder%3DanyKey%26f%3Dx%26gdpr%3DA%26uid%3D%24UID%24",
+			expectedRendered: "https://bidder.com/sync?redirect=http%3A%2F%2Fsyncer.com%2Fsetuid%3Fbidder%3DanyKey%26f%3Dx%26gdpr%3DA%26gpp%3DD%26gpp_sid%3D1%26uid%3D%24UID%24",
 		},
 		{
 			description: "Redirect URL + External URL From Host",

--- a/util/ptrutil/ptrutil.go
+++ b/util/ptrutil/ptrutil.go
@@ -1,0 +1,5 @@
+package ptrutil
+
+func ToPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
Alternative to #12, pass all of `imp.ext` except `prebid` and `bidder`, merged with `customParameters` from `imp.ext.bidder`